### PR TITLE
generate emoji images without md5 digest

### DIFF
--- a/lib/open_project/emoji/engine.rb
+++ b/lib/open_project/emoji/engine.rb
@@ -30,5 +30,9 @@ module OpenProject::Emoji
     initializer 'emoji.precompile_assets' do |app|
       app.config.assets.precompile += ['emojify.js', 'emoji.js', 'emoji.css']
     end
+
+    config.to_prepare do |app|
+      NonStupidDigestAssets.whitelist << /emojis\/.*\.png/
+    end
   end
 end


### PR DESCRIPTION
Sprockets seems to generate every image with digests now.
However, in emojify.js (which does not belong to us but to
the upstream repository) we do not (and don't want to) use
image-url('..') or similar things to generate the actual
digested path of each emoji image.

Instead we use the non-stupid-digest-assets gem (which
is already required by OpenProject) to whitelist our
images from digestion :)

fixes #3
