### PR TITLE
Use Rails 4's assets path

### DIFF
--- a/app/assets/javascripts/emoji.js.erb
+++ b/app/assets/javascripts/emoji.js.erb
@@ -20,7 +20,7 @@ jQuery(function ($) {
     emojify_tag_type  : 'div',                        // Only run emojify.js on this element
     emoticons_enabled : true,                         // enable emoticons
     only_crawl_id     : null,                         // Use to restrict where emojify.js applies
-    img_dir           : '<%= image_path 'emojis' %>', // Directory for emoji images
+    img_dir           : '<%= "#{Rails.application.config.assets.prefix}/emojis" %>', // Directory for emoji images
     ignored_tags      : {                             // Ignore the following tags
         'SCRIPT'  : 1,
         'TEXTAREA': 1,
@@ -47,7 +47,7 @@ jQuery(function ($) {
           at: ':',
           start_with_space: true,
           data: emojify.emojiNames,
-          tpl: "<li data-value=':${name}:'><img src='<%= image_path 'emojis' %>/${name}.png' height='20' width='20'/> ${name} </li>"
+          tpl: "<li data-value=':${name}:'><img src='<%= "#{Rails.application.config.assets.prefix}/emojis" %>/${name}.png' height='20' width='20'/> ${name} </li>"
         });
       }
     });


### PR DESCRIPTION
The corresponding work package: https://community.openproject.org/work_packages/21436.

Unfortunately, I see no way to use `asset_path` since at the time of precompiling the assets, the name of the image is unknown. Thus, `asset_path 'emojis'` return `/emojis`, i.e. without `/assets`. See also here: http://serverfault.com/a/638933.